### PR TITLE
Joeg/sid refactor

### DIFF
--- a/controls/02_account_lockout_spec.rb
+++ b/controls/02_account_lockout_spec.rb
@@ -35,7 +35,7 @@ control 'windows-account-100' do
   title 'Windows Remote Desktop Configured to Only Allow System Administrators Access'
   describe security_policy do
     # verifies that only the 'Administrators' group has remote access
-    its('SeRemoteInteractiveLogonRight') { should eq 'S-1-5-32-544' }
+    its('SeRemoteInteractiveLogonRight') { should eq ['S-1-5-32-544'] }
   end
 end
 

--- a/controls/02_account_lockout_spec.rb
+++ b/controls/02_account_lockout_spec.rb
@@ -35,7 +35,7 @@ control 'windows-account-100' do
   title 'Windows Remote Desktop Configured to Only Allow System Administrators Access'
   describe security_policy do
     # verifies that only the 'Administrators' group has remote access
-    its('SeRemoteInteractiveLogonRight') { should eq '*S-1-5-32-544' }
+    its('SeRemoteInteractiveLogonRight') { should eq 'S-1-5-32-544' }
   end
 end
 

--- a/controls/03_user_rights_spec.rb
+++ b/controls/03_user_rights_spec.rb
@@ -7,7 +7,7 @@ control 'cis-access-cred-manager-2.2.1' do
   title '2.2.1 Set Access Credential Manager as a trusted caller to No One'
   desc 'Set Access Credential Manager as a trusted caller to No One'
   describe security_policy do
-    its('SeTrustedCredManAccessPrivilege') { should eq 'S-1-0-0' }
+    its('SeTrustedCredManAccessPrivilege') { should eq ['S-1-0-0'] }
   end
 end
 
@@ -16,7 +16,7 @@ control 'cis-network-access-2.2.2' do
   title '2.2.2 Set Access this computer from the network'
   desc 'Set Access this computer from the network'
   describe security_policy do
-    its('SeNetworkLogonRight') { should eq 'S-1-0' }
+    its('SeNetworkLogonRight') { should eq ['S-1-0'] }
   end
 end
 
@@ -25,7 +25,7 @@ control 'cis-act-as-os-2.2.3' do
   title '2.2.3 Set Act as part of the operating system to No One'
   desc 'Set Act as part of the operating system to No One'
   describe security_policy do
-    its('SeTcbPrivilege') { should eq 'S-1-0-0' }
+    its('SeTcbPrivilege') { should eq ['S-1-0-0'] }
   end
 end
 
@@ -34,7 +34,7 @@ control 'cis-add-workstations-2.2.4' do
   title '2.2.4 Set Add workstations to domain to Administrators'
   desc 'Set Add workstations to domain to Administrators'
   describe security_policy do
-    its('SeMachineAccountPrivilege') { should eq 'S-1-5-32-544' }
+    its('SeMachineAccountPrivilege') { should eq ['S-1-5-32-544'] }
   end
 end
 
@@ -43,8 +43,8 @@ control 'cis-adjust-memory-quotas-2.2.5' do
   title '2.2.5 Set Adust memory quotas for a process to Administrators, LOCAL SERVICE, NETWORK SERVICE'
   desc 'Set Adust memory quotas for a process to Administrators, LOCAL SERVICE, NETWORK SERVICE'
   describe security_policy do
-    its('SeIncreaseQuotaPrivilege') { should match(/\S-1-5-19,?/) }
-    its('SeIncreaseQuotaPrivilege') { should match(/\S-1-5-20,?/) }
-    its('SeIncreaseQuotaPrivilege') { should match(/\S-1-5-32-544,?/) }
+    its('SeIncreaseQuotaPrivilege') { should include 'S-1-5-19' }
+    its('SeIncreaseQuotaPrivilege') { should include 'S-1-5-20' }
+    its('SeIncreaseQuotaPrivilege') { should include 'S-1-5-32-544' }
   end
 end

--- a/controls/03_user_rights_spec.rb
+++ b/controls/03_user_rights_spec.rb
@@ -34,7 +34,7 @@ control 'cis-add-workstations-2.2.4' do
   title '2.2.4 Set Add workstations to domain to Administrators'
   desc 'Set Add workstations to domain to Administrators'
   describe security_policy do
-    its('SeMachineAccountPrivilege') { should eq '*S-1-5-32-544' }
+    its('SeMachineAccountPrivilege') { should eq 'S-1-5-32-544' }
   end
 end
 
@@ -43,8 +43,8 @@ control 'cis-adjust-memory-quotas-2.2.5' do
   title '2.2.5 Set Adust memory quotas for a process to Administrators, LOCAL SERVICE, NETWORK SERVICE'
   desc 'Set Adust memory quotas for a process to Administrators, LOCAL SERVICE, NETWORK SERVICE'
   describe security_policy do
-    its('SeIncreaseQuotaPrivilege') { should match(/\*S-1-5-19,?/) }
-    its('SeIncreaseQuotaPrivilege') { should match(/\*S-1-5-20,?/) }
-    its('SeIncreaseQuotaPrivilege') { should match(/\*S-1-5-32-544,?/) }
+    its('SeIncreaseQuotaPrivilege') { should match(/\S-1-5-19,?/) }
+    its('SeIncreaseQuotaPrivilege') { should match(/\S-1-5-20,?/) }
+    its('SeIncreaseQuotaPrivilege') { should match(/\S-1-5-32-544,?/) }
   end
 end

--- a/controls/03_user_rights_spec.rb
+++ b/controls/03_user_rights_spec.rb
@@ -7,7 +7,7 @@ control 'cis-access-cred-manager-2.2.1' do
   title '2.2.1 Set Access Credential Manager as a trusted caller to No One'
   desc 'Set Access Credential Manager as a trusted caller to No One'
   describe security_policy do
-    its('SeTrustedCredManAccessPrivilege') { is_expected.to be_nil }
+    its('SeTrustedCredManAccessPrivilege') { should eq 'S-1-0-0' }
   end
 end
 
@@ -16,7 +16,7 @@ control 'cis-network-access-2.2.2' do
   title '2.2.2 Set Access this computer from the network'
   desc 'Set Access this computer from the network'
   describe security_policy do
-    its('SeNetworkLogonRight') { is_expected.to_not be_nil }
+    its('SeNetworkLogonRight') { should eq 'S-1-0' }
   end
 end
 
@@ -25,7 +25,7 @@ control 'cis-act-as-os-2.2.3' do
   title '2.2.3 Set Act as part of the operating system to No One'
   desc 'Set Act as part of the operating system to No One'
   describe security_policy do
-    its('SeTcbPrivilege') { is_expected.to be_nil }
+    its('SeTcbPrivilege') { should eq 'S-1-0-0' }
   end
 end
 


### PR DESCRIPTION
Due to behaviour of the security policy resource in InSpec, the SID matchers always failed with the wildcard stripped out. See - https://github.com/chef/inspec/blame/master/lib/resources/security_policy.rb#L148

- switched SID matchers to arrays
- set nil values to relevant default SIDs of Nobody or Null from here: https://support.microsoft.com/en-gb/kb/243330

Hardening from the base windows cookbook now passes - https://github.com/chef-cft/base-win2012-hardening